### PR TITLE
Added ability to duplicate a workflow or send it to another user

### DIFF
--- a/Multi_Page_WebApp/flask_app/climate_simulation_platform/app.py
+++ b/Multi_Page_WebApp/flask_app/climate_simulation_platform/app.py
@@ -36,6 +36,7 @@ from climate_simulation_platform.db import (
     add_info,
     get_coord_names,
     get_file_path,
+    get_all_usernames,
     get_file_type_counts,
     get_file_types,
     get_filename,
@@ -44,6 +45,9 @@ from climate_simulation_platform.db import (
     get_lon_lat_names,
     is_data_file,
     load_file,
+    duplicate_data_files,
+    duplicate_revisions,
+    duplicate_steps,
     remove_data_file,
     set_data_file_coords,
     steps_seen,
@@ -183,13 +187,40 @@ def download_all(_id):
     )
 
 
+@bp.route("/<int:_id>/send", methods=("GET", "POST"))
+@login_required
+@user_required
+def send(_id):
+    if request.method == "POST":
+        receiver = request.form["Username"]
+        duplicate_data_files(_id, receiver)
+        duplicate_revisions(_id)
+        duplicate_steps(_id)
+        flash("File with id: {} sent to {}".format(_id, receiver), 'info')
+        return redirect(url_for("index"))
+
+    user_names = get_all_usernames()
+    return render_template("app/send.html", _id=_id, user_names=user_names)
+
+
+@bp.route("/<int:_id>/duplicate", methods=("GET", "POST"))
+@login_required
+@user_required
+def duplicate(_id):
+    if request.method == "POST":
+        duplicate_data_files(_id)
+        duplicate_revisions(_id)
+        duplicate_steps(_id)
+        flash("File with id: {} duplicated".format(_id), 'success')
+    return redirect(url_for("index"))
+
 @bp.route("/<int:_id>/delete", methods=("GET", "POST"))
 @login_required
 @user_required
 def delete(_id):
     if request.method == "POST":
         remove_data_file(_id)
-        flash("File deleted with id: {}".format(_id))
+        flash("File with id: {} deleted".format(_id), 'danger')
     return redirect(url_for("index"))
 
 

--- a/Multi_Page_WebApp/flask_app/climate_simulation_platform/db_schema.sql
+++ b/Multi_Page_WebApp/flask_app/climate_simulation_platform/db_schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE data_files (
   longitude TEXT,
   latitude TEXT,
   info TEXT,
+  state TEXT,
   FOREIGN KEY (owner_id) REFERENCES user (id)
 );
 

--- a/Multi_Page_WebApp/flask_app/climate_simulation_platform/static/style.css
+++ b/Multi_Page_WebApp/flask_app/climate_simulation_platform/static/style.css
@@ -31,6 +31,7 @@ a {
 hr {
   border: none;
   border-top: 1px solid lightgray;
+  margin: 12px 0px;
 }
 
 nav {
@@ -68,6 +69,7 @@ nav ul li a, nav ul li span, header .action {
 
 .content > header {
   border-bottom: 1px solid lightgray;
+  margin-bottom: 12px;
   display: flex;
   align-items: flex-end;
 }
@@ -86,17 +88,33 @@ nav ul li a, nav ul li span, header .action {
 
 .post > header {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   font-size: 0.85em;
+  height: 61px;
 }
 
-.post > header > div:first-of-type {
+.post > header > div {
   flex: auto;
+  display: flex;
+  /* align-items: center; */
 }
 
 .post > header h1 {
   font-size: 1.5em;
-  margin-bottom: 0;
+  margin: 0;
+}
+
+.post > header > div > a > .duplicated {
+  margin: 0px; 
+  color:#30a746;
+}
+.post > header > div > a > .received {
+  margin: 0px; 
+  color:#32a2b8;
+}
+
+.post > header > form {
+  margin-left: 5px;
 }
 
 .post .about {

--- a/Multi_Page_WebApp/flask_app/climate_simulation_platform/templates/app/datafiles.html
+++ b/Multi_Page_WebApp/flask_app/climate_simulation_platform/templates/app/datafiles.html
@@ -14,12 +14,22 @@
 <article class="post">
     <header>
         <div>
-            <a class="action" href="{{ url_for('app.steps', _id=df['id']) }}">
-                <h1>{{ df['filename'] }} Last Modified on {{ df['created'].strftime('%Y-%m-%d')
-                    }}</h1>
+            <a class="action" href="{{ url_for('app.steps', _id=df['id']) }}" style="white-space: nowrap">
+                <h1>{{ df['filename'] }} Last Modified on {{ df['created'].strftime('%Y-%m-%d')}}</h1>
+                {% if df['state'] and "DUPLICATED" in df['state'] %}
+                    <p class="duplicated"> [{{ df['state'] }}]</p>
+                {% elif df['state'] and "RECEIVED" in df['state'] %}
+                    <p class="received"> [{{ df['state'] }}] </p>
+                {% endif %}
             </a>
         </div>
         <a class="action" href="{{ url_for('app.set_coords', _id=df['id']) }}">Set Coordinates</a>
+        <form action="{{ url_for('app.send', _id=df['id']) }}">
+            <button type="submit" class="btn btn-info btn-sm"><i class="fas fa-share"></i> SEND</button>
+        </form>
+        <form action="{{ url_for('app.duplicate', _id=df['id']) }}" method="POST">
+            <button type="submit" class="btn btn-success btn-sm"><i class="fas fa-clone"></i> DUPLICATE</button>
+        </form>
         <form action="{{ url_for('app.delete', _id=df['id']) }}" method="POST">
             <button type="submit" class="btn btn-danger btn-sm"><i class="fas fa-trash"></i> DELETE</button>
         </form>

--- a/Multi_Page_WebApp/flask_app/climate_simulation_platform/templates/app/send.html
+++ b/Multi_Page_WebApp/flask_app/climate_simulation_platform/templates/app/send.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+{% block header %}
+<h1>{% block title %}Send workflow to another user{% endblock %}</h1>
+{% endblock %}
+
+{% block content %}
+<form method='POST'>
+  <label for="Username">User</label>
+  <select name="Username">
+    {% for name in user_names %}
+        <option value="{{ name }}">{{ name }}</option>
+    {% endfor %}
+  </select>
+  <br><br>
+  <button type="submit" class="btn btn-success btn-lg"><i class="fas fa-paper-plane"></i> Send</button>
+</form>
+{% endblock %}

--- a/Multi_Page_WebApp/flask_app/climate_simulation_platform/templates/base.html
+++ b/Multi_Page_WebApp/flask_app/climate_simulation_platform/templates/base.html
@@ -77,8 +77,11 @@
     <header>
       {% block header %}{% endblock %}
     </header>
-    {% for message in get_flashed_messages() %}
-    <div class="flash">{{ message }}</div>
+    {% for category, message in get_flashed_messages(with_categories=True) %}
+    <!-- <div class="flash"> -->
+    <div class="alert alert-{{ category }} alert-dismissible" role="alert">
+      {{ message }}
+    </div>
     {% endfor %}
     {% block content %}{% endblock %}
   </section>


### PR DESCRIPTION
- 2 new buttons added to **duplicate/send** a workflow
- When clicking on one of those buttons for a specific workflow, all the entries in the database and all the generated files relative to this workflow are duplicated
- Clicking on *send* button will lead to a new page where the receiver of the workflow can be chosen
- New column **state** added in *data_files* table of the database in order to track if the workflow has been **duplicated/sent**